### PR TITLE
Do explicit zero-length checking for certain HTTP requests that break Pa...

### DIFF
--- a/app/app.rb
+++ b/app/app.rb
@@ -40,7 +40,7 @@ module Spirit
 
     # TODO: middleware that checks Content-Type text/xml and attempts to parse request like this
     before do # Set plist object on @request_payload if request content was text/xml
-      if request.media_type == 'text/xml' && request.content_length
+      if request.media_type == 'text/xml' && request.content_length.to_i > 0
         request.body.rewind
         post_plist = CFPropertyList::List.new({
             format: CFPropertyList::List::FORMAT_XML,


### PR DESCRIPTION
...ssenger.

While testing Spirit I noticed that renaming scripts was failing in DS Admin. In order to troubleshoot I ran the site with rackup and had no issues. Fast-forward past 2 hours of packet sniffing and debug trace reading when I  figured out that the POST request for the rename (/scripts/ren) is being sent as text/xml with a zero content_length which triggers processing by CFPropertyList. This fails with NilClass errors, because there's nothing to parse. I suspect that WeBRick processes the POST request with zero length by not passing content_length while Passenger does, thus triggering the XML parsing with CFPropertyList of nil content.

Anyway. Changing the check from simply "content_length exists" to "content_length is not zero length" seems to successfully skip over the XML parsing.
